### PR TITLE
fixed footer & image highlight

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -12,7 +12,10 @@
   <title>About</title>
   <meta name="description" content="Working notes on data mining and early book history.">
 
-  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />
+  <!-- Fonts -->
+  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />  
+
+  <!-- Main CSS -->
   <link rel="stylesheet" href="/css/duhaime.css" media="screen,projection" />
   <link rel="stylesheet" href="/css/footer.css" media="screen,projection" />
 
@@ -64,8 +67,8 @@
 
     <footer class="site-footer">
   <div class="wrapper">
-    <ul class="social-media-list" style="text-align: center">
-   
+    <ul class="social-media-list">
+
     
       <a href="https://github.com/duhaime" style="text-decoration: none">
   <span class="icon icon--github"><svg viewBox="0 0 16 16"><path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/></svg>

--- a/css/duhaime.css
+++ b/css/duhaime.css
@@ -611,8 +611,16 @@ footer {
 }
 
 
+#img-link-wrapper, #img-link img {
+   text-decoration: none !important;
+   border:0px !important;
+   outline:none;
+   border-width: 0px;
+   outline-width:0px;
+}
 
-#img-link{
-  text-decoration:none;
+.site-footer {
+  margin-left: -68px;
+  text-align: center; 
 }
 

--- a/css/meyer-reset.css
+++ b/css/meyer-reset.css
@@ -1,0 +1,48 @@
+* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+    display: block;
+}
+body {
+    line-height: 1;
+}
+ol, ul {
+    list-style: none;
+}
+blockquote, q {
+    quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: '';
+    content: none;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}

--- a/feed.xml
+++ b/feed.xml
@@ -5,8 +5,8 @@
     <description>Working notes on data mining and early book history.</description>
     <link>http://yourdomain.com/</link>
     <atom:link href="http://yourdomain.com/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Sun, 15 Nov 2015 11:00:53 -0500</pubDate>
-    <lastBuildDate>Sun, 15 Nov 2015 11:00:53 -0500</lastBuildDate>
+    <pubDate>Sun, 15 Nov 2015 12:07:41 -0500</pubDate>
+    <lastBuildDate>Sun, 15 Nov 2015 12:07:41 -0500</lastBuildDate>
     <generator>Jekyll v3.0.0</generator>
     
       <item>
@@ -343,7 +343,7 @@ for v in [v2,v3]:
 
 &lt;p&gt;One of the debates surrounding the Act of Anne concerns the degree to which the statute altered the geography of the English book trade. Prior to the passage of the Act, legal historian Diane Zimmerman notes, the Stationers’ Company dominated the book industry, and because the company’s printers were primarily stationed in London, the book trade was also centered in the metropole. With the passage of the Statute of Anne, however, authors could sell or trade their copyrights to printers outside of London: “Now any printer [or] bookseller, wherever located within the country, could register a copyright with the Company” and “since purchasers of the copies could be located anywhere in the United Kingdom, the Stationers’ Company did not regain its monopoly [on the book trade]” (7). Contra Zimmerman, William Patry argues that the Act of Anne failed to undermine London’s control of the book trade: “After the Statute of Anne, as before,” he writes, “the only purchasers of authors’ works were a small group of London booksellers” (&lt;a href=&quot;https://books.google.com/books?id=8-4catWPy84C&amp;amp;q=%22small+group+of+London+booksellers%22#v=snippet&amp;amp;q=%22small%20group%20of%20London%20booksellers%22&amp;amp;f=false&quot;&gt;84&lt;/a&gt;). To investigate what the ESTC had to say on this question, I compared the geographical distribution of English printers in the half centuries before and after the passage of the Act (click for full size):&lt;/p&gt;
 
-&lt;p&gt;&lt;a id=&quot;img-link&quot; href=&quot;/images/post_images/mapping_early_english_books/provincial_printing.png&quot; data-lightbox=&quot;provincial_printing&quot; data-title=&quot;My caption&quot;&gt;
+&lt;p&gt;&lt;a id=&quot;img-link-wrapper&quot; href=&quot;/images/post_images/mapping_early_english_books/provincial_printing.png&quot; data-lightbox=&quot;provincial_printing&quot; data-title=&quot;My caption&quot;&gt;
   &lt;img id=&quot;img-link&quot; src=&quot;/images/post_images/mapping_early_english_books/provincial_printing.png&quot; alt=&quot;Provincial Printing&quot; style=&quot;width:100%&quot; /&gt;&lt;/a&gt;&lt;/p&gt;
 
 </description>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,10 @@
   <title>Douglas Duhaime</title>
   <meta name="description" content="Working notes on data mining and early book history.">
 
-  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />
+  <!-- Fonts -->
+  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />  
+
+  <!-- Main CSS -->
   <link rel="stylesheet" href="/css/duhaime.css" media="screen,projection" />
   <link rel="stylesheet" href="/css/footer.css" media="screen,projection" />
 
@@ -97,8 +100,8 @@
 
     <footer class="site-footer">
   <div class="wrapper">
-    <ul class="social-media-list" style="text-align: center">
-   
+    <ul class="social-media-list">
+
     
       <a href="https://github.com/duhaime" style="text-decoration: none">
   <span class="icon icon--github"><svg viewBox="0 0 16 16"><path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/></svg>

--- a/posts/clustering-semantic-vectors.html
+++ b/posts/clustering-semantic-vectors.html
@@ -12,7 +12,10 @@
   <title>Clustering Semantic Vectors</title>
   <meta name="description" content="Google’s Word2Vec and Stanford’s GloVe have recently offered two fantastic open source software packages capable of transposing words into a high dimension v...">
 
-  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />
+  <!-- Fonts -->
+  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />  
+
+  <!-- Main CSS -->
   <link rel="stylesheet" href="/css/duhaime.css" media="screen,projection" />
   <link rel="stylesheet" href="/css/footer.css" media="screen,projection" />
 
@@ -193,8 +196,8 @@ import sys, codecs, numpy</code></pre>
 
     <footer class="site-footer">
   <div class="wrapper">
-    <ul class="social-media-list" style="text-align: center">
-   
+    <ul class="social-media-list">
+
     
       <a href="https://github.com/duhaime" style="text-decoration: none">
   <span class="icon icon--github"><svg viewBox="0 0 16 16"><path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/></svg>

--- a/posts/crosslingual-plagiarism-detection.html
+++ b/posts/crosslingual-plagiarism-detection.html
@@ -12,7 +12,10 @@
   <title>Crosslingual Plagiarism Detection with Scikit-Learn</title>
   <meta name="description" content="">
 
-  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />
+  <!-- Fonts -->
+  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />  
+
+  <!-- Main CSS -->
   <link rel="stylesheet" href="/css/duhaime.css" media="screen,projection" />
   <link rel="stylesheet" href="/css/footer.css" media="screen,projection" />
 
@@ -222,8 +225,8 @@ for v in [v2,v3]:
 
     <footer class="site-footer">
   <div class="wrapper">
-    <ul class="social-media-list" style="text-align: center">
-   
+    <ul class="social-media-list">
+
     
       <a href="https://github.com/duhaime" style="text-decoration: none">
   <span class="icon icon--github"><svg viewBox="0 0 16 16"><path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/></svg>

--- a/posts/mapping-the-early-english-book-trade.html
+++ b/posts/mapping-the-early-english-book-trade.html
@@ -12,7 +12,10 @@
   <title>Mapping the Early English Book Trade</title>
   <meta name="description" content="">
 
-  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />
+  <!-- Fonts -->
+  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />  
+
+  <!-- Main CSS -->
   <link rel="stylesheet" href="/css/duhaime.css" media="screen,projection" />
   <link rel="stylesheet" href="/css/footer.css" media="screen,projection" />
 
@@ -60,7 +63,7 @@
 
 <p>One of the debates surrounding the Act of Anne concerns the degree to which the statute altered the geography of the English book trade. Prior to the passage of the Act, legal historian Diane Zimmerman notes, the Stationers’ Company dominated the book industry, and because the company’s printers were primarily stationed in London, the book trade was also centered in the metropole. With the passage of the Statute of Anne, however, authors could sell or trade their copyrights to printers outside of London: “Now any printer [or] bookseller, wherever located within the country, could register a copyright with the Company” and “since purchasers of the copies could be located anywhere in the United Kingdom, the Stationers’ Company did not regain its monopoly [on the book trade]” (7). Contra Zimmerman, William Patry argues that the Act of Anne failed to undermine London’s control of the book trade: “After the Statute of Anne, as before,” he writes, “the only purchasers of authors’ works were a small group of London booksellers” (<a href="https://books.google.com/books?id=8-4catWPy84C&amp;q=%22small+group+of+London+booksellers%22#v=snippet&amp;q=%22small%20group%20of%20London%20booksellers%22&amp;f=false">84</a>). To investigate what the ESTC had to say on this question, I compared the geographical distribution of English printers in the half centuries before and after the passage of the Act (click for full size):</p>
 
-<p><a id="img-link" href="/images/post_images/mapping_early_english_books/provincial_printing.png" data-lightbox="provincial_printing" data-title="My caption">
+<p><a id="img-link-wrapper" href="/images/post_images/mapping_early_english_books/provincial_printing.png" data-lightbox="provincial_printing" data-title="My caption">
   <img id="img-link" src="/images/post_images/mapping_early_english_books/provincial_printing.png" alt="Provincial Printing" style="width:100%" /></a></p>
 
 
@@ -72,8 +75,8 @@
 
     <footer class="site-footer">
   <div class="wrapper">
-    <ul class="social-media-list" style="text-align: center">
-   
+    <ul class="social-media-list">
+
     
       <a href="https://github.com/duhaime" style="text-decoration: none">
   <span class="icon icon--github"><svg viewBox="0 0 16 16"><path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/></svg>

--- a/secret/index.html
+++ b/secret/index.html
@@ -12,7 +12,10 @@
   <title>Douglas Duhaime</title>
   <meta name="description" content="Working notes on data mining and early book history.">
 
-  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />
+  <!-- Fonts -->
+  <link rel="stylesheet" href="http://fast.fonts.com/cssapi/d70ca5cd-778e-48cc-9e59-6b276425c670.css" type="text/css" media="screen,projection" />  
+
+  <!-- Main CSS -->
   <link rel="stylesheet" href="/css/duhaime.css" media="screen,projection" />
   <link rel="stylesheet" href="/css/footer.css" media="screen,projection" />
 
@@ -67,8 +70,8 @@
 
     <footer class="site-footer">
   <div class="wrapper">
-    <ul class="social-media-list" style="text-align: center">
-   
+    <ul class="social-media-list">
+
     
       <a href="https://github.com/duhaime" style="text-decoration: none">
   <span class="icon icon--github"><svg viewBox="0 0 16 16"><path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/></svg>


### PR DESCRIPTION
This pr centers the social media footer and removes image highlighting for images targeted with `image-link-wrapper` and then `image-link` ids.
